### PR TITLE
Added dependencies and fixed paths in open call

### DIFF
--- a/Sakurajima/models/base_models.py
+++ b/Sakurajima/models/base_models.py
@@ -313,7 +313,7 @@ class Episode(object):
             os.mkdir("chunks")
         except FileExistsError:
             pass
-        with open(f"chunks\/{file_name}-{chunk_num}.chunk.ts", "wb") as videofile:
+        with open(f"chunks/{file_name}-{chunk_num}.chunk.ts", "wb") as videofile:
             res = requests.get(segment["uri"], cookies=self.__cookies, headers=headers)
             chunk = res.content
             key_dict = segment.get("key", None)
@@ -382,9 +382,9 @@ class Episode(object):
             concat = '"concat'
             for x in range(0, total_chunks):
                 if x == 0:
-                    concat += f":chunks\/{file_name}-{x}.chunk.ts"
+                    concat += f":chunks/{file_name}-{x}.chunk.ts"
                 else:
-                    concat += f"|chunks\/{file_name}-{x}.chunk.ts"
+                    concat += f"|chunks/{file_name}-{x}.chunk.ts"
             concat += '"'
             subprocess.run(f'ffmpeg -i {concat} -c copy "{file_name}.mp4"')
 
@@ -392,14 +392,14 @@ class Episode(object):
             print("Merging chunks into mp4")
             with open(f"{file_name}.mp4", "wb") as merged:
                 for ts_file in [
-                    f"chunks\/{file_name}-{x}.chunk.ts" for x in range(0, total_chunks)
+                    f"chunks/{file_name}-{x}.chunk.ts" for x in range(0, total_chunks)
                 ]:
                     with open(ts_file, "rb") as ts:
                         shutil.copyfileobj(ts, merged)
         if delete_chunks:
             for x in range(0, total_chunks):
                 # Remove chunk files
-                os.remove(f"chunks\/{file_name}-{x}.chunk.ts")
+                os.remove(f"chunks/{file_name}-{x}.chunk.ts")
 
     def get_available_qualities(self):
         aniwatch_episode = self.get_aniwatch_episode()

--- a/setup.py
+++ b/setup.py
@@ -18,4 +18,9 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.6",
+    install_requires=[
+        "requests==2.23.0",
+        "pycryptodome==3.9.7",
+        "m3u8==0.6.0",
+    ],
 )


### PR DESCRIPTION
When I installed Sakurajima through pip, no required dependencies were installed. I added them to the setup file.

Also when trying to execute your example main.py with my corresponding credentials, downloads failed because the chunk files couldn't be created, as the paths were not valid.